### PR TITLE
47: add validation for edit note and remove unneeded lookups for config changes

### DIFF
--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteModel.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteModel.kt
@@ -14,5 +14,15 @@ interface EditNoteModel {
      * creates in-memory Note object based on existing item and the new data
      */
     fun buildNote(oldNote: Note, newNoteTitle: String, newNoteBody: String) : Note
+
+    /**
+     * Returns true if valid and false otherwise
+     */
+    fun validateNoteTitleText(text: String): Boolean
+
+    /**
+     * Returns true if valid and false otherwise
+     */
+    fun validateNoteBodyText(text: String): Boolean
 }
 

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteModelImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteModelImpl.kt
@@ -12,7 +12,7 @@ class EditNoteModelImpl(private val repository: Repository) : EditNoteModel {
     override fun buildNote(oldNote: Note, newNoteTitle: String, newNoteBody: String): Note
             = Note(oldNote.id, newNoteTitle, newNoteBody, oldNote.created, System.currentTimeMillis())
 
-    override fun validateNoteTitleText(text: String): Boolean = !text.isNullOrEmpty()
+    override fun validateNoteTitleText(text: String): Boolean = !text.isNullOrBlank()
 
-    override fun validateNoteBodyText(text: String): Boolean = !text.isNullOrEmpty()
+    override fun validateNoteBodyText(text: String): Boolean = !text.isNullOrBlank()
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteModelImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteModelImpl.kt
@@ -11,4 +11,8 @@ class EditNoteModelImpl(private val repository: Repository) : EditNoteModel {
     override fun editNote(note: Note) = repository.saveNote(note)
     override fun buildNote(oldNote: Note, newNoteTitle: String, newNoteBody: String): Note
             = Note(oldNote.id, newNoteTitle, newNoteBody, oldNote.created, System.currentTimeMillis())
+
+    override fun validateNoteTitleText(text: String): Boolean = !text.isNullOrEmpty()
+
+    override fun validateNoteBodyText(text: String): Boolean = !text.isNullOrEmpty()
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
@@ -32,6 +32,24 @@ class EditNotePresenter(private val view: EditNoteView,
         setupSaveNoteSubscription(noteId)
 
         view.cancelEditNoteClicks().map { null }.subscribe(showNewNoteDetailSubscriberFn).addToComposite()
+
+        setupTextViewsChanged()
+    }
+
+    fun setupTextViewsChanged() {
+        view.titleTextChanges()
+                .map { model.validateNoteTitleText(view.getNewNoteTitle()) }
+                .doOnNext { if (!it) { view.showInvalidNoteTitleError(); view.toggleSubmit(false) } }
+                // filters out anything that doesn't match the predicate (only emit true events (the text is valid).
+                .filter { it }
+                .subscribe { view.toggleSubmit(validateAllFields()) }
+
+        view.bodyTextChanges()
+                .map { model.validateNoteBodyText(view.getNewNoteBody()) }
+                .doOnNext { if (!it) { view.showInvalidNoteBodyError(); view.toggleSubmit(false) } }
+                // filters out anything that doesn't match the predicate (only emit true events (the text is valid).
+                .filter { it }
+                .subscribe { view.toggleSubmit(validateAllFields()) }
     }
 
     fun setupGetNoteDetailSubscription(noteId: String) {
@@ -81,4 +99,8 @@ class EditNotePresenter(private val view: EditNoteView,
     }
 
     internal fun buildNote(oldNote: Note): Note = model.buildNote(oldNote, view.getNewNoteTitle(), view.getNewNoteBody())
+
+    internal fun validateAllFields(): Boolean {
+        return model.validateNoteTitleText(view.getNewNoteTitle()) && model.validateNoteBodyText(view.getNewNoteBody())
+    }
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
@@ -25,9 +25,7 @@ class EditNotePresenter(private val view: EditNoteView,
         screenBundleHelper.setTitle(args, R.string.edit_note_screen_title)
         val noteId: String = screenBundleHelper.getNoteId(args)
 
-        if (!view.isDataInitialized()) {
-            setupGetNoteDetailSubscription(noteId)
-        }
+        setupGetNoteDetailSubscription(noteId)
 
         setupSaveNoteSubscription(noteId)
 
@@ -55,6 +53,7 @@ class EditNotePresenter(private val view: EditNoteView,
     fun setupGetNoteDetailSubscription(noteId: String) {
         model.getNote(noteId).subscribe(object : SingleSubscriber<Note>() {
             override fun onSuccess(note: Note) {
+                Timber.d("looking up note")
                 view.setNoteData(note)
             }
 

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
@@ -25,7 +25,9 @@ class EditNotePresenter(private val view: EditNoteView,
         screenBundleHelper.setTitle(args, R.string.edit_note_screen_title)
         val noteId: String = screenBundleHelper.getNoteId(args)
 
-        setupGetNoteDetailSubscription(noteId)
+        if (!view.isDataInitialized()) {
+            setupGetNoteDetailSubscription(noteId)
+        }
 
         setupSaveNoteSubscription(noteId)
 

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
@@ -36,16 +36,14 @@ class EditNotePresenter(private val view: EditNoteView,
 
     fun setupTextViewsChanged() {
         view.titleTextChanges()
-                .map { model.validateNoteTitleText(view.getNewNoteTitle()) }
+                .map { model.validateNoteTitleText(it.toString()) }
                 .doOnNext { if (!it) { view.showInvalidNoteTitleError(); view.toggleSubmit(false) } }
-                // filters out anything that doesn't match the predicate (only emit true events (the text is valid).
                 .filter { it }
                 .subscribe { view.toggleSubmit(validateAllFields()) }
 
         view.bodyTextChanges()
-                .map { model.validateNoteBodyText(view.getNewNoteBody()) }
+                .map { model.validateNoteBodyText(it.toString()) }
                 .doOnNext { if (!it) { view.showInvalidNoteBodyError(); view.toggleSubmit(false) } }
-                // filters out anything that doesn't match the predicate (only emit true events (the text is valid).
                 .filter { it }
                 .subscribe { view.toggleSubmit(validateAllFields()) }
     }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
@@ -53,7 +53,6 @@ class EditNotePresenter(private val view: EditNoteView,
     fun setupGetNoteDetailSubscription(noteId: String) {
         model.getNote(noteId).subscribe(object : SingleSubscriber<Note>() {
             override fun onSuccess(note: Note) {
-                Timber.d("looking up note")
                 view.setNoteData(note)
             }
 

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteView.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteView.kt
@@ -12,10 +12,15 @@ interface EditNoteView : BaseView {
     fun setNoteData(note: Note)
     fun cancelEditNoteClicks(): Observable<Unit>
     fun saveNoteClicks(): Observable<Unit>
+    fun titleTextChanges(): Observable<CharSequence>
+    fun bodyTextChanges(): Observable<CharSequence>
     fun showNewNoteDetail(args: Bundle)
     fun showUnableToLoadNoteError()
     fun showUnableToSaveNoteError()
+    fun showInvalidNoteTitleError()
+    fun showInvalidNoteBodyError()
     fun getNewNoteTitle(): String
     fun getNewNoteBody(): String
     fun isDataInitialized(): Boolean
+    fun toggleSubmit(inputValid: Boolean)
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteView.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteView.kt
@@ -21,6 +21,5 @@ interface EditNoteView : BaseView {
     fun showInvalidNoteBodyError()
     fun getNewNoteTitle(): String
     fun getNewNoteBody(): String
-    fun isDataInitialized(): Boolean
     fun toggleSubmit(inputValid: Boolean)
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteView.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteView.kt
@@ -17,4 +17,5 @@ interface EditNoteView : BaseView {
     fun showUnableToSaveNoteError()
     fun getNewNoteTitle(): String
     fun getNewNoteBody(): String
+    fun isDataInitialized(): Boolean
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
@@ -11,6 +11,7 @@ import com.exallium.todoapp.app.TodoApp
 import com.exallium.todoapp.entities.Note
 import com.exallium.todoapp.mvp.BaseViewImpl
 import com.jakewharton.rxbinding.view.clicks
+import com.jakewharton.rxbinding.widget.textChanges
 import rx.Observable
 
 /**
@@ -43,12 +44,17 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     override fun setNoteData(note: Note) {
         noteTitleEditText.setText(note.title)
         noteBodyTextView.setText(note.body)
+        noteBodyTextView.textChanges()
         dataInitialized = true
     }
 
     override fun cancelEditNoteClicks(): Observable<Unit> = cancelEditNote.clicks()
 
     override fun saveNoteClicks(): Observable<Unit> = saveNote.clicks()
+
+    override fun titleTextChanges(): Observable<CharSequence> = noteTitleEditText.textChanges()
+
+    override fun bodyTextChanges(): Observable<CharSequence> = noteBodyTextView.textChanges()
 
     override fun showNewNoteDetail(args: Bundle) {
         view?.hideKeyboard(applicationContext?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
@@ -69,6 +75,18 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
 
     override fun showUnableToSaveNoteError() {
         displaySnackbar(R.string.unable_to_save_note_error)
+    }
+
+    override fun showInvalidNoteTitleError() {
+        displaySnackbar(R.string.invalid_note_title_error)
+    }
+
+    override fun showInvalidNoteBodyError() {
+        displaySnackbar(R.string.invalid_note_body_error)
+    }
+
+    override fun toggleSubmit(enable: Boolean) {
+        saveNote.isEnabled = enable
     }
 
     override fun isDataInitialized(): Boolean {

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import butterknife.BindString
 import butterknife.BindView
 import com.exallium.todoapp.R
 import com.exallium.todoapp.app.TodoApp
@@ -24,13 +25,19 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     lateinit var noteTitleEditText: EditText
 
     @BindView(R.id.edit_note_body)
-    lateinit var noteBodyTextView: EditText
+    lateinit var noteBodyEditText: EditText
 
     @BindView(R.id.edit_note_cancel_button)
     lateinit var cancelEditNote: View
 
     @BindView(R.id.edit_note_save_button)
     lateinit var saveNote: View
+
+    @BindString(R.string.invalid_note_title_error)
+    lateinit var noteTitleError: String
+
+    @BindString(R.string.invalid_note_body_error)
+    lateinit var noteBodyError: String
 
     override fun getComponent(): EditNoteComponent = DaggerEditNoteComponent.builder()
             .todoAppComponent(TodoApp.component)
@@ -41,7 +48,7 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
 
     override fun setNoteData(note: Note) {
         noteTitleEditText.setText(note.title)
-        noteBodyTextView.setText(note.body)
+        noteBodyEditText.setText(note.body)
     }
 
     override fun cancelEditNoteClicks(): Observable<Unit> = cancelEditNote.clicks()
@@ -50,7 +57,7 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
 
     override fun titleTextChanges(): Observable<CharSequence> = noteTitleEditText.textChanges()
 
-    override fun bodyTextChanges(): Observable<CharSequence> = noteBodyTextView.textChanges()
+    override fun bodyTextChanges(): Observable<CharSequence> = noteBodyEditText.textChanges()
 
     override fun showNewNoteDetail(args: Bundle) {
         view?.hideKeyboard(applicationContext?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
@@ -62,7 +69,7 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     }
 
     override fun getNewNoteBody(): String {
-        return noteBodyTextView.text.toString()
+        return noteBodyEditText.text.toString()
     }
 
     override fun showUnableToLoadNoteError() {
@@ -74,18 +81,14 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     }
 
     override fun showInvalidNoteTitleError() {
-        noteTitleEditText.error = resources!!.getString(R.string.invalid_note_title_error)
+        noteTitleEditText.error = noteTitleError
     }
 
     override fun showInvalidNoteBodyError() {
-        noteBodyTextView.error = resources!!.getString(R.string.invalid_note_body_error)
+        noteBodyEditText.error = noteBodyError
     }
 
     override fun toggleSubmit(enable: Boolean) {
         saveNote.isEnabled = enable
-    }
-
-    private fun View.hideKeyboard(inputMethodManager: InputMethodManager) {
-        inputMethodManager.hideSoftInputFromWindow(windowToken, 0)
     }
 }

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
@@ -31,6 +31,8 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     @BindView(R.id.edit_note_save_button)
     lateinit var saveNote: View
 
+    private var dataInitialized: Boolean = false
+
     override fun getComponent(): EditNoteComponent = DaggerEditNoteComponent.builder()
             .todoAppComponent(TodoApp.component)
             .editNoteModule(EditNoteModule(this))
@@ -41,6 +43,7 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     override fun setNoteData(note: Note) {
         noteTitleEditText.setText(note.title)
         noteBodyTextView.setText(note.body)
+        dataInitialized = true
     }
 
     override fun cancelEditNoteClicks(): Observable<Unit> = cancelEditNote.clicks()
@@ -66,6 +69,10 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
 
     override fun showUnableToSaveNoteError() {
         displaySnackbar(R.string.unable_to_save_note_error)
+    }
+
+    override fun isDataInitialized(): Boolean {
+        return dataInitialized
     }
 
     private fun View.hideKeyboard(inputMethodManager: InputMethodManager) {

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
@@ -44,7 +44,6 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     override fun setNoteData(note: Note) {
         noteTitleEditText.setText(note.title)
         noteBodyTextView.setText(note.body)
-        noteBodyTextView.textChanges()
         dataInitialized = true
     }
 

--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNoteViewImpl.kt
@@ -32,8 +32,6 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     @BindView(R.id.edit_note_save_button)
     lateinit var saveNote: View
 
-    private var dataInitialized: Boolean = false
-
     override fun getComponent(): EditNoteComponent = DaggerEditNoteComponent.builder()
             .todoAppComponent(TodoApp.component)
             .editNoteModule(EditNoteModule(this))
@@ -44,7 +42,6 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     override fun setNoteData(note: Note) {
         noteTitleEditText.setText(note.title)
         noteBodyTextView.setText(note.body)
-        dataInitialized = true
     }
 
     override fun cancelEditNoteClicks(): Observable<Unit> = cancelEditNote.clicks()
@@ -77,19 +74,15 @@ class EditNoteViewImpl(val bundle: Bundle) : BaseViewImpl<EditNoteView, EditNote
     }
 
     override fun showInvalidNoteTitleError() {
-        displaySnackbar(R.string.invalid_note_title_error)
+        noteTitleEditText.error = resources!!.getString(R.string.invalid_note_title_error)
     }
 
     override fun showInvalidNoteBodyError() {
-        displaySnackbar(R.string.invalid_note_body_error)
+        noteBodyTextView.error = resources!!.getString(R.string.invalid_note_body_error)
     }
 
     override fun toggleSubmit(enable: Boolean) {
         saveNote.isEnabled = enable
-    }
-
-    override fun isDataInitialized(): Boolean {
-        return dataInitialized
     }
 
     private fun View.hideKeyboard(inputMethodManager: InputMethodManager) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="edit_note_screen_title">Edit Note</string>
     <string name="unable_to_load_note_error">Error loading Note for editing</string>
     <string name="unable_to_save_note_error">Error saving Note</string>
+    <string name="invalid_note_title_error">Title cannot be empty</string>
+    <string name="invalid_note_body_error">Body cannot be empty</string>
     <string name="edit_note_cancel_button_text">Cancel</string>
     <string name="edit_note_save_button_text">Save</string>
 

--- a/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNoteModelImplTest.kt
+++ b/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNoteModelImplTest.kt
@@ -71,4 +71,52 @@ class EditNoteModelImplTest {
         Assert.assertEquals(oldNote.created, result.created)
         Assert.assertNotNull(result.updated)
     }
+
+    @Test
+    fun validateNoteTitleText_whenTitleIsEmpty_returnsFalse() {
+        // GIVEN
+        val newNoteTitle: String = ""
+
+        // WHEN
+        val result = testSubject.validateNoteTitleText(newNoteTitle)
+
+        // THEN
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun validateNoteTitleText_whenTitleIsNotEmpty_returnsFalse() {
+        // GIVEN
+        val newNoteTitle: String = "asdf"
+
+        // WHEN
+        val result = testSubject.validateNoteTitleText(newNoteTitle)
+
+        // THEN
+        Assert.assertTrue(result)
+    }
+
+    @Test
+    fun validateNoteBodyText_whenBodyIsEmpty_returnsFalse() {
+        // GIVEN
+        val newNoteBody: String = ""
+
+        // WHEN
+        val result = testSubject.validateNoteBodyText(newNoteBody)
+
+        // THEN
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun validateNoteBodyText_whenBodyIsNotEmpty_returnsFalse() {
+        // GIVEN
+        val newNoteBody: String = "asdf"
+
+        // WHEN
+        val result = testSubject.validateNoteBodyText(newNoteBody)
+
+        // THEN
+        Assert.assertTrue(result)
+    }
 }

--- a/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
+++ b/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
@@ -109,6 +109,18 @@ class EditNotePresenterTest {
     }
 
     @Test
+    fun onViewCreated_setupTextViewsChanged() {
+        // GIVEN
+        testSubject = spy(testSubject)
+
+        // WHEN
+        testSubject.onViewCreated()
+
+        // THEN
+        verify(testSubject).setupTextViewsChanged()
+    }
+
+    @Test
     fun buildNote_buildsNewNoteObjectUsingOldAndNewData() {
         // GIVEN
         val oldNote: Note = mock()

--- a/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
+++ b/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
@@ -70,22 +70,9 @@ class EditNotePresenterTest {
         // THEN
         verify(screenBundleHelper).getNoteId(bundle)
     }
-
+    
     @Test
-    fun onViewCreated_whenDataIsInitialized_doesNotSetupGetNoteDetailSubscription() {
-        // GIVEN
-        testSubject = spy(testSubject)
-        whenever(view.isDataInitialized()).thenReturn(true)
-
-        // WHEN
-        testSubject.onViewCreated()
-
-        // THEN
-        verify(testSubject, never()).setupGetNoteDetailSubscription(TEST_NOTE_ID_STRING)
-    }
-
-    @Test
-    fun onViewCreated_whenDataNotInitialized_setupGetNoteDetailSubscription() {
+    fun onViewCreated_setupGetNoteDetailSubscription() {
         // GIVEN
         testSubject = spy(testSubject)
 

--- a/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
+++ b/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
@@ -4,10 +4,7 @@ import android.os.Bundle
 import com.exallium.todoapp.R
 import com.exallium.todoapp.entities.Note
 import com.exallium.todoapp.screenbundle.ScreenBundleHelper
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Answers
@@ -75,7 +72,20 @@ class EditNotePresenterTest {
     }
 
     @Test
-    fun onViewCreated_setupGetNoteDetailSubscription() {
+    fun onViewCreated_whenDataIsInitialized_doesNotSetupGetNoteDetailSubscription() {
+        // GIVEN
+        testSubject = spy(testSubject)
+        whenever(view.isDataInitialized()).thenReturn(true)
+
+        // WHEN
+        testSubject.onViewCreated()
+
+        // THEN
+        verify(testSubject, never()).setupGetNoteDetailSubscription(TEST_NOTE_ID_STRING)
+    }
+
+    @Test
+    fun onViewCreated_whenDataNotInitialized_setupGetNoteDetailSubscription() {
         // GIVEN
         testSubject = spy(testSubject)
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Behavior in action can be viewed here: https://drive.google.com/open?id=0B-5eHbqh90ciaXFYMTV6blM1b1U