### PR TITLE
27: add tests for EditNotePresenter

### DIFF
--- a/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
+++ b/app/src/main/kotlin/com/exallium/todoapp/editnote/EditNotePresenter.kt
@@ -50,9 +50,6 @@ class EditNotePresenter(view: EditNoteView,
     }
 
     fun setupTextChangedSubscription() {
-        fun validateAllFields(): Boolean {
-            return model.validateNoteTitleText(view.getNoteTitle()) && model.validateNoteBodyText(view.getNoteBody())
-        }
 
         fun setupTextChangedValidation(textChangedObservable: Observable<CharSequence>,
                                        validationFn: (String) -> Boolean,
@@ -72,6 +69,10 @@ class EditNotePresenter(view: EditNoteView,
 
         setupTextChangedValidation(view.titleTextChanges(), model::validateNoteTitleText, view::showInvalidNoteTitleError)
         setupTextChangedValidation(view.bodyTextChanges(), model::validateNoteBodyText, view::showInvalidNoteBodyError)
+    }
+
+    fun validateAllFields(): Boolean {
+        return model.validateNoteTitleText(view.getNoteTitle()) && model.validateNoteBodyText(view.getNoteBody())
     }
 
     /**

--- a/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
+++ b/app/src/test/kotlin/com/exallium/todoapp/editnote/EditNotePresenterTest.kt
@@ -2,7 +2,9 @@ package com.exallium.todoapp.editnote
 
 import android.os.Bundle
 import com.exallium.todoapp.R
+import com.exallium.todoapp.entities.Note
 import com.exallium.todoapp.repository.IdFactory
+import com.exallium.todoapp.repository.RepositoryException
 import com.exallium.todoapp.screenbundle.ScreenBundleHelper
 import com.nhaarman.mockito_kotlin.*
 import org.junit.Before
@@ -11,31 +13,32 @@ import org.mockito.Answers
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import rx.Single
 
 /**
  * Unit testing for {@link EditNotePresenter}
  */
 class EditNotePresenterTest {
 
-    private val TEST_NOTE_ID_STRING = "test note id"
+    val TEST_NOTE_ID_STRING = "test note id"
 
     @InjectMocks
-    private lateinit var testSubject: EditNotePresenter
+    lateinit var testSubject: EditNotePresenter
 
     @Mock(answer = Answers.RETURNS_MOCKS)
-    private lateinit var view: EditNoteView
+    lateinit var view: EditNoteView
 
     @Mock(answer = Answers.RETURNS_MOCKS)
-    private lateinit var model: EditNoteModel
+    lateinit var model: EditNoteModel
 
     @Mock(answer = Answers.RETURNS_MOCKS)
-    private lateinit var screenBundleHelper: ScreenBundleHelper
+    lateinit var screenBundleHelper: ScreenBundleHelper
 
     @Mock(answer = Answers.RETURNS_MOCKS)
-    private lateinit var idFactory: IdFactory
+    lateinit var idFactory: IdFactory
 
     @Mock
-    private lateinit var bundle: Bundle
+    lateinit var bundle: Bundle
 
     @Before
     fun setUp() {
@@ -151,4 +154,31 @@ class EditNotePresenterTest {
         // THEN
         verify(testSubject).setupTextChangedSubscription()
     }
+
+    @Test
+    fun setupGetNoteDetailSubscription_whenNoteIdIsSet_andNoteIsFound_setsNoteData() {
+        // GIVEN
+        val note = getTestNote()
+        whenever(model.getNote(TEST_NOTE_ID_STRING)).thenReturn(Single.just(note))
+
+        // WHEN
+        testSubject.setupGetNoteDetailSubscription(TEST_NOTE_ID_STRING)
+
+        // THEN
+        verify(view).setNoteData(note)
+    }
+
+    @Test
+    fun setupGetNoteDetailSubscription_whenNoteIdIsSet_andNoteIsNotFound_showsUnableToLoadNoteError() {
+        // GIVEN
+        whenever(model.getNote(TEST_NOTE_ID_STRING)).thenReturn(Single.error(RepositoryException("")))
+
+        // WHEN
+        testSubject.setupGetNoteDetailSubscription(TEST_NOTE_ID_STRING)
+
+        // THEN
+        verify(view).showUnableToLoadNoteError()
+    }
+
+    private fun getTestNote() = Note(TEST_NOTE_ID_STRING, "", "", 0, 0)
 }


### PR DESCRIPTION
<img width="895" alt="screen shot 2017-03-15 at 5 51 17 pm" src="https://cloud.githubusercontent.com/assets/5749794/23972469/3d708532-09a8-11e7-9b03-2f8f3515433f.png">

The only parts not covered (branches missed -- not sure how)
<img width="892" alt="screen shot 2017-03-15 at 5 53 16 pm" src="https://cloud.githubusercontent.com/assets/5749794/23972482/4f78c0d2-09a8-11e7-8f15-129b2deb7ecc.png">
